### PR TITLE
S3 Image upload fix

### DIFF
--- a/src/Http/Controllers/EditorJsImageUploadController.php
+++ b/src/Http/Controllers/EditorJsImageUploadController.php
@@ -107,6 +107,9 @@ class EditorJsImageUploadController extends Controller
             if (!empty($alterations)) {
                 $imageSettings = $alterations;
             }
+            
+            if(empty($imageSettings))
+                return;
 
             if (!empty($imageSettings['resize']['width'])) {
                 $image->width($imageSettings['resize']['width']);


### PR DESCRIPTION
Spatie image library does not support s3 yet. This change will help us in disabling the image manipulation altogether.