### PR TITLE
Fixed non-string values crashing the HTML converter

### DIFF
--- a/src/NovaEditorJs.php
+++ b/src/NovaEditorJs.php
@@ -62,7 +62,7 @@ class NovaEditorJs extends Field
     }
 
     /**
-     * @param $jsonData
+     * @param string|mixed $jsonData
      * @return string
      * @throws \Throwable
      */
@@ -70,6 +70,14 @@ class NovaEditorJs extends Field
     {
         if (empty($jsonData)) {
             return '';
+        }
+
+        // Clean non-string data
+        if (!is_string($jsonData)) {
+            $newData = json_encode($jsonData);
+            if (json_last_error() === \JSON_ERROR_NONE) {
+                $jsonData = $newData;
+            }
         }
 
         $config = config('nova-editor-js.validationSettings');


### PR DESCRIPTION
Added support to add the property on your model that's casted to an array or such (via the `$casts` property) to still be passed to the HTML formatter.

Also see #26 for more information