### PR TITLE
Fix parse image name with query

### DIFF
--- a/src/Http/Controllers/EditorJsImageUploadController.php
+++ b/src/Http/Controllers/EditorJsImageUploadController.php
@@ -80,7 +80,7 @@ class EditorJsImageUploadController extends Controller
 
         $url = $request->input('url');
         $imageContents = file_get_contents($url);
-        $name = substr($url, strrpos($url, '/') + 1);
+        $name = parse_url(substr($url, strrpos($url, '/') + 1))['path'];
         $nameWithPath = config('nova-editor-js.toolSettings.image.path') . '/' . uniqid() . $name;
 
         Storage::disk(config('nova-editor-js.toolSettings.image.disk'))->put($nameWithPath, $imageContents);
@@ -107,7 +107,7 @@ class EditorJsImageUploadController extends Controller
             if (!empty($alterations)) {
                 $imageSettings = $alterations;
             }
-            
+
             if(empty($imageSettings))
                 return;
 


### PR DESCRIPTION
Sometimes the image come from cdn, so the image name could be "foo.jpg?width=25&height=250". This will ensure we remove the query from the file name, so the file name save in the storage should be corrected
