### PR TITLE
Fix NovaEditorJsData constructor issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+- Constructor of `NovaEditorJsData` now accepts null values and non-iterables.
+
 ## [3.0.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [3.0.2]
+
+### Added
+- Support for `spatie/image` version 2.x.
+
+## [3.0.1]
+
+### Fixed
+- `composer.json` didn't require PHP 8.1+, but the codebase did.
+
+## [3.0.0]
+
 ### Added
 - Nova 4 support
 - `NovaEditorJsConverter` to split HTML conversion from the Nova Field
@@ -48,7 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For older changes before v2.0.0, please see the [releases page](https://github.com/advoor/nova-editor-js/releases).
 
-[unreleased]: https://github.com/advoor/nova-editor-js/compare/v2.0.3..master
+[unreleased]: https://github.com/advoor/nova-editor-js/compare/v3.0.2..master
+[3.0.2]: https://github.com/advoor/nova-editor-js/releases/v3.0.2
+[3.0.1]: https://github.com/advoor/nova-editor-js/releases/v3.0.1
+[3.0.0]: https://github.com/advoor/nova-editor-js/releases/v3.0.0
 [2.0.3]: https://github.com/advoor/nova-editor-js/releases/v2.0.3
 [2.0.2]: https://github.com/advoor/nova-editor-js/releases/v2.0.2
 [2.0.0]: https://github.com/advoor/nova-editor-js/releases/v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Constructor of `NovaEditorJsData` now accepts null values and non-iterables.
+- PHPDoc return type of `NovaEditorJsData::toHtml()`.
 
 ## [3.0.2]
 

--- a/src/NovaEditorJsData.php
+++ b/src/NovaEditorJsData.php
@@ -33,7 +33,7 @@ class NovaEditorJsData extends Fluent implements Htmlable, Stringable
     }
 
     /**
-     * @return \Advoor\NovaEditorJs\HtmlString
+     * @return \Illuminate\Support\HtmlString
      */
     public function toHtml()
     {

--- a/src/NovaEditorJsData.php
+++ b/src/NovaEditorJsData.php
@@ -4,6 +4,7 @@ namespace Advoor\NovaEditorJs;
 
 use Advoor\NovaEditorJs\NovaEditorJs;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use Stringable;
 
@@ -20,6 +21,10 @@ class NovaEditorJsData extends Fluent implements Htmlable, Stringable
     {
         if (is_string($attributes)) {
             $attributes = json_decode($attributes);
+        }
+
+        if (! is_iterable($attributes)) {
+            $attributes = Arr::wrap($attributes);
         }
 
         foreach ($attributes as $key => $value) {


### PR DESCRIPTION
In certain scenarios, the `NovaEditorJsData` data model would recieve a `null` value as constructor argument.  
This would crash the foreach loop.

Now, the `NovaEditorJsData` accepts all data types, decoding strings as JSON (as it did before), and wrapping non-iterables in an array.

Closes #65 