### PR TITLE
Added php-cs-fixer and php-parallel-lint

### DIFF
--- a/.github/workflows/auto-format-code.yml
+++ b/.github/workflows/auto-format-code.yml
@@ -1,0 +1,40 @@
+name: Auto-format code
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Auto-format code using php-cs-fixer
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: '8.1'
+          extensions: exif,json,mbstring
+          coverage: none
+
+      - name: Configure local Laravel Nova dummy package
+        run: composer config repositories.0 path ./tests/Fixtures/nova
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "--ignore-platform-req=php"
+          dependency-versions: highest # No lockfile is present, so locked (the default) isn't possible
+
+      - name: Lint code
+        run: composer run format
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Fixed code style using PHP-CS-Fixer
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
           composer-options: "--ignore-platform-req=php"
           dependency-versions: highest # No lockfile is present, so locked (the default) isn't possible
 
+      - name: Lint code
+        run: composer run lint
+
       - name: Run unit tests
         run:
           vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ composer.lock
 .phpunit.result.cache
 .DS_Store
 Thumbs.db
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,6 +19,13 @@ return (new Config())
     ->setRules([
         '@PSR12' => true,
 
+        // Consistent naming of PHPUnit methods
+        'php_unit_method_casing' => ['case' => 'camel_case'],
+        'php_unit_test_annotation' => ['style' => 'prefix'],
+
+        // Remove duplicate entries from phpdoc (like `@param string` on a typed method, without further info)
+        'no_superfluous_phpdoc_tags' => true,
+
         // Ensure strict types are used
         'declare_strict_types' => true,
         'strict_param' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()
+    ->in([
+        'src',
+        'tests',
+        'routes',
+    ]);
+
+return (new Config())
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+    ->setCacheFile('.php-cs-fixer.cache')
+    ->setRules([
+        '@PSR12' => true,
+
+        // Ensure strict types are used
+        'declare_strict_types' => true,
+        'strict_param' => true,
+    ]);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Guzzle is now a dependency of this project.
+- Added `php-cs-fixer` for code standards.
+- Added `php-parallel-lint` to ensure all files are actually valid PHP code.
 
 ### Changed
 - Improved image upload handling, using Laravel-native libraries

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "spatie/image": "^1.7 || ^2.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.9",
         "orchestra/testbench": "^6.0 || ^7.0"
     },
     "autoload": {
@@ -40,6 +41,14 @@
     },
     "scripts-descriptions": {
         "test": "Test application using PHPUnit."
+    },
+    "scripts": {
+        "format": [
+            "php-cs-fixer fix"
+        ]
+    },
+    "scripts-descriptions": {
+        "format": "Run php-cs-fixer formatter"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9",
-        "orchestra/testbench": "^6.0 || ^7.0"
+        "orchestra/testbench": "^6.0 || ^7.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3"
     },
     "autoload": {
         "psr-4": {
@@ -43,11 +44,15 @@
         "test": "Test application using PHPUnit."
     },
     "scripts": {
+        "lint": [
+            "parallel-lint --exclude .git --exclude vendor ."
+        ],
         "format": [
             "php-cs-fixer fix"
         ]
     },
     "scripts-descriptions": {
+        "lint": "Lint all php files",
         "format": "Run php-cs-fixer formatter"
     },
     "extra": {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Facades\Route;
 
-use \Advoor\NovaEditorJs\Http\Controllers\EditorJsImageUploadController;
-use \Advoor\NovaEditorJs\Http\Controllers\EditorJsLinkController;
+use Advoor\NovaEditorJs\Http\Controllers\EditorJsImageUploadController;
+use Advoor\NovaEditorJs\Http\Controllers\EditorJsLinkController;
 
 Route::post('upload/file', EditorJsImageUploadController::class . '@file')->name('editor-js-upload-image-by-file');
 Route::post('upload/url', EditorJsImageUploadController::class . '@url')->name('editor-js-upload-image-by-url');

--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Advoor\NovaEditorJs;
 
 use Laravel\Nova\Nova;

--- a/src/Http/Controllers/EditorJsImageUploadController.php
+++ b/src/Http/Controllers/EditorJsImageUploadController.php
@@ -48,7 +48,6 @@ class EditorJsImageUploadController extends Controller
         );
 
         if (config('nova-editor-js.toolSettings.image.disk') !== 'local') {
-
             $tempPath = $request->file('image')->store(
                 config('nova-editor-js.toolSettings.image.path'),
                 'local'
@@ -134,8 +133,9 @@ class EditorJsImageUploadController extends Controller
                 $imageSettings = $alterations;
             }
 
-            if (empty($imageSettings))
+            if (empty($imageSettings)) {
                 return;
+            }
 
             if (!empty($imageSettings['resize']['width'])) {
                 $image->width($imageSettings['resize']['width']);
@@ -181,7 +181,6 @@ class EditorJsImageUploadController extends Controller
             }
 
             $image->save();
-
         } catch (InvalidManipulation $exception) {
             report($exception);
         }

--- a/src/NovaEditorJs.php
+++ b/src/NovaEditorJs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Advoor\NovaEditorJs;
 
 use Illuminate\Support\Facades\Facade;

--- a/src/NovaEditorJsCast.php
+++ b/src/NovaEditorJsCast.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Advoor\NovaEditorJs;
 
 use Illuminate\Support\Str;
@@ -16,7 +18,6 @@ class NovaEditorJsCast implements CastsAttributes
     /**
      * Returns an instance of the EditorJsData field warning the user
      * the data is corrupted.
-     * @return NovaEditorJsData
      */
     private static function getErrorObject(string $exceptionMessage): NovaEditorJsData
     {
@@ -42,10 +43,6 @@ class NovaEditorJsCast implements CastsAttributes
      * Cast the given value.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  array  $attributes
-     * @return NovaEditorJsData|null
      */
     public function get($model, string $key, $value, array $attributes): ?NovaEditorJsData
     {
@@ -66,10 +63,6 @@ class NovaEditorJsCast implements CastsAttributes
      * Prepare the given value for storage.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  array  $attributes
-     * @return array
      */
     public function set($model, string $key, $value, array $attributes): array
     {

--- a/src/NovaEditorJsConverter.php
+++ b/src/NovaEditorJsConverter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Advoor\NovaEditorJs;
 
 use Closure;
@@ -27,7 +29,6 @@ class NovaEditorJsConverter
      *
      * @param string   $block  Name of the block, as defined in the JSON
      * @param callable $callback  Closure that returns a string (or a Stringable)
-     * @return void
      */
     public function addRender(string $block, callable $callback): void
     {
@@ -37,7 +38,6 @@ class NovaEditorJsConverter
     /**
      * Renders the given EditorJS data to safe HTML.
      *
-     * @param mixed $data
      * @return \Illuminate\Support\HtmlString Safe, directly returnable string.
      */
     public function generateHtmlOutput(mixed $data): HtmlString

--- a/src/NovaEditorJsData.php
+++ b/src/NovaEditorJsData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Advoor\NovaEditorJs;
 
 use Advoor\NovaEditorJs\NovaEditorJs;

--- a/src/NovaEditorJsField.php
+++ b/src/NovaEditorJsField.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Advoor\NovaEditorJs;
 
 use JsonException;
@@ -34,7 +36,6 @@ class NovaEditorJsField extends Field
     /**
      * Resolve the field's value for display.
      *
-     * @param mixed $resource
      * @param string|null $attribute
      * @throws \Throwable
      */

--- a/src/config/nova-editor-js.php
+++ b/src/config/nova-editor-js.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     /**
      * Editor settings

--- a/tests/Fixtures/nova/src/Events/ServingNova.php
+++ b/tests/Fixtures/nova/src/Events/ServingNova.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laravel\Nova\Events;
 
 class ServingNova

--- a/tests/Fixtures/nova/src/StaticallyUselessClass.php
+++ b/tests/Fixtures/nova/src/StaticallyUselessClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laravel\Nova;
 
 class StaticallyUselessClass

--- a/tests/Fixtures/nova/src/UselessServiceProvider.php
+++ b/tests/Fixtures/nova/src/UselessServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laravel\Nova;
 
 use Illuminate\Support\ServiceProvider;

--- a/tests/Fixtures/nova/src/aliases.php
+++ b/tests/Fixtures/nova/src/aliases.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laravel\Nova;
 
 class_alias(StaticallyUselessClass::class, Nova::class);
@@ -21,4 +23,3 @@ class_alias(StaticallyUselessClass::class, Panel::class);
 class_alias(StaticallyUselessClass::class, Resource::class);
 
 class_alias(StaticallyUselessClass::class, Fields\Field::class);
-

--- a/tests/Unit/Http/Controllers/EditorJsImageUploadControllerTest.php
+++ b/tests/Unit/Http/Controllers/EditorJsImageUploadControllerTest.php
@@ -33,7 +33,7 @@ class EditorJsImageUploadControllerTest extends TestCase
      * @param string $path Path to the image file
      * @dataProvider provideValidFilesForImageUpload
      */
-    public function test_image_upload(string $path): void
+    public function testImageUpload(string $path): void
     {
         Storage::fake();
         Storage::fake('public');
@@ -67,7 +67,7 @@ class EditorJsImageUploadControllerTest extends TestCase
     /**
      * Test uploading a non-image.
      */
-    public function test_non_image_upload(): void
+    public function testNonImageUpload(): void
     {
         Storage::fake();
         Storage::fake('public');
@@ -85,7 +85,7 @@ class EditorJsImageUploadControllerTest extends TestCase
      * @param string $file path to the file returned by the URL
      * @dataProvider provideValidFiles
      */
-    public function test_valid_image_url_submission(string $file): void
+    public function testValidImageUrlSubmission(string $file): void
     {
         Storage::fake();
         Storage::fake('public');
@@ -113,7 +113,7 @@ class EditorJsImageUploadControllerTest extends TestCase
     /**
      * Test submitting a non-image URL causes the request to fail.
      */
-    public function test_invalid_image_url_submission(): void
+    public function testInvalidImageUrlSubmission(): void
     {
         Http::fake([
             'https://example.com/image.bin' => Http::response('Hello World!'),
@@ -128,7 +128,7 @@ class EditorJsImageUploadControllerTest extends TestCase
      * Test submitting a URL that's not valid, but is a properly formed HTTP
      * URL, still sends out a ping (but fails, eventually).
      */
-    public function test_submitting_a_dead_url(): void
+    public function testSubmittingADeadUrl(): void
     {
         Http::fake([
             'https://example.invalid/image.bin' => Http::response('Hello World!'),
@@ -145,7 +145,7 @@ class EditorJsImageUploadControllerTest extends TestCase
      * Test submitting a URL which the server won't or cannot provide returns an error.
      * Also implicitly handles timeouts, since that's the same block.
      */
-    public function test_submitting_image_url_with_errors(): void
+    public function testSubmittingImageUrlWithErrors(): void
     {
         Http::fake([
             'https://example.com/client/image.bin' => Http::response(test_resource('responses/image.png'), Response::HTTP_BAD_GATEWAY),

--- a/tests/Unit/Http/Controllers/EditorJsLinkControllerTest.php
+++ b/tests/Unit/Http/Controllers/EditorJsLinkControllerTest.php
@@ -24,7 +24,8 @@ class EditorJsLinkControllerTest extends TestCase
     /**
      * Checks simple URL fetch.
      */
-    public function testFetchValidUrl(): void {
+    public function testFetchValidUrl(): void
+    {
         Http::fake([
             'https://example.com' => Http::response(file_get_contents(test_resource('responses/simple.html'))),
         ])->preventStrayRequests();
@@ -43,7 +44,8 @@ class EditorJsLinkControllerTest extends TestCase
     /**
      * Checks simple URL fetch.
      */
-    public function testImageDetermination(): void {
+    public function testImageDetermination(): void
+    {
         Http::fake([
             'https://example.com' => Http::response(file_get_contents(test_resource('responses/with-image.html'))),
         ])->preventStrayRequests();

--- a/tests/Unit/JsonContentTest.php
+++ b/tests/Unit/JsonContentTest.php
@@ -30,8 +30,6 @@ class JsonContentTest extends TestCase
 
     /**
      * A basic test example.
-     *
-     * @return void
      */
     public function testStringValue(): void
     {
@@ -51,8 +49,6 @@ class JsonContentTest extends TestCase
 
     /**
      * A basic test example.
-     *
-     * @return void
      */
     public function testJsonValue(): void
     {


### PR DESCRIPTION
This should make further contributions easier to verify, and more consistent.

The php-cs-fixer config is _slightly_ opinionated towards modern code (PSR12 + `strict_types`).  
It also adds a few rules about unit tests, to ensure consistent naming.

php-cs-fixer is auto-applied on the `master` branch, so new contributor don't have to worry about styling, It'll be fixed for them.