### PR TITLE
Allow tools to be set per-field

### DIFF
--- a/src/NovaEditorJsField.php
+++ b/src/NovaEditorJsField.php
@@ -72,4 +72,15 @@ class NovaEditorJsField extends Field
 
         $this->value = call_user_func($this->displayCallback, $value);
     }
+    
+    /**
+    *
+    * @param array $tools
+    *
+    */
+    
+    public function tools(array $tools)
+    {
+        return $this->withMeta(["toolSettings" => $tools]);
+    }
 }


### PR DESCRIPTION
This allows tool config to be set on an individual field, which is very useful when Editor.js is being used in multiple places within Nova and different tools are desired in each place.