### PR TITLE
Do not ignore resolve callbacks when displaying

### DIFF
--- a/src/NovaEditorJsField.php
+++ b/src/NovaEditorJsField.php
@@ -52,6 +52,10 @@ class NovaEditorJsField extends Field
 
         $value = data_get($resource, str_replace('->', '.', $attribute), $placeholder = new \stdClass());
 
+        if (is_callable($this->resolveCallback)) {
+            $value = call_user_func($this->resolveCallback, $value, $resource, $attribute);
+        }
+
         if (!$this->displayCallback) {
             $this->withMeta(['asHtml' => true]);
             $this->value = (string) NovaEditorJs::generateHtmlOutput($value);


### PR DESCRIPTION
Currently the display of the field value ignores previously set resolve callbacks in Nova. This can lead to the package not playing nice with other packages that manipulate fields, like Spatie's Laravel Translatable. 

This patch solved that issue by checking for resolve callbacks before deciding the field's display value.