### PR TITLE
Nova 5 support

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -23,12 +23,15 @@ jobs:
         laravel:
           - '10.0'
           - '11.0'
+          - '12.0'
 
         include:
           - laravel: '10.0'
             testbench: '8.0'
           - laravel: '11.0'
             testbench: '9.0'
+          - laravel: '12.0'
+            testbench: '10.0'
           - php: 8.3
             laravel: '11.0'
             stable: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 Thumbs.db
 .php-cs-fixer.cache
 /composer.lock
+/auth.json
+/report-junit.xml
+/.env

--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,8 @@
     "prefer-stable": true,
     "repositories": [
         {
-            "type": "path",
-            "url": "./tests/Fixtures/nova"
+            "type": "composer",
+            "url": "https://nova.laravel.com"
         }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,15 @@
         "ext-json": "*",
         "codex-team/editor.js": "*",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/support": "^10.0 || ^11.0",
-        "illuminate/events": "^10.0 || ^11.0",
-        "laravel/nova": "^4.0",
+        "illuminate/events": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+        "laravel/laravel": "^12",
+        "laravel/nova": "^4.0 || ^5.0",
         "spatie/image": "^3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.15",
-        "orchestra/testbench": "^8.0 || ^9.0",
+        "orchestra/testbench": "^10",
         "php-parallel-lint/php-parallel-lint": "^1.3"
     },
     "autoload": {
@@ -66,8 +67,8 @@
     "prefer-stable": true,
     "repositories": [
         {
-            "type": "composer",
-            "url": "https://nova.laravel.com"
+            "type": "path",
+            "url": "./tests/Fixtures/nova"
         }
     ]
 }

--- a/src/Events/EditorJsImageUploaded.php
+++ b/src/Events/EditorJsImageUploaded.php
@@ -10,7 +10,5 @@ class EditorJsImageUploaded
 {
     use Dispatchable;
 
-    public function __construct(public string $disk, public string $path)
-    {
-    }
+    public function __construct(public string $disk, public string $path) {}
 }

--- a/src/Events/EditorJsThumbnailCreated.php
+++ b/src/Events/EditorJsThumbnailCreated.php
@@ -10,7 +10,5 @@ class EditorJsThumbnailCreated
 {
     use Dispatchable;
 
-    public function __construct(public string $disk, public string $path)
-    {
-    }
+    public function __construct(public string $disk, public string $path) {}
 }

--- a/src/Http/Controllers/EditorJsImageUploadController.php
+++ b/src/Http/Controllers/EditorJsImageUploadController.php
@@ -103,7 +103,7 @@ class EditorJsImageUploadController extends Controller
         }
 
         // Validate mime type
-        $mime = (new finfo())->buffer($response->body(), FILEINFO_MIME_TYPE);
+        $mime = (new finfo)->buffer($response->body(), FILEINFO_MIME_TYPE);
         if (! in_array($mime, self::VALID_IMAGE_MIMES, true)) {
             return response()->json([
                 'success' => 0,

--- a/src/Http/Controllers/EditorJsLinkController.php
+++ b/src/Http/Controllers/EditorJsLinkController.php
@@ -40,7 +40,7 @@ class EditorJsLinkController extends Controller
             ]);
         }
 
-        $doc = new DOMDocument();
+        $doc = new DOMDocument;
         @$doc->loadHTML((string) $response->getBody());
         $nodes = $doc->getElementsByTagName('title');
         $title = $nodes->item(0)->nodeValue;

--- a/src/NovaEditorJsConverter.php
+++ b/src/NovaEditorJsConverter.php
@@ -43,7 +43,7 @@ class NovaEditorJsConverter
      */
     public function generateHtmlOutput(mixed $data): HtmlString
     {
-        if (empty($data) || $data == new stdClass()) {
+        if (empty($data) || $data == new stdClass) {
             return new HtmlString('');
         }
 

--- a/src/NovaEditorJsField.php
+++ b/src/NovaEditorJsField.php
@@ -40,11 +40,10 @@ class NovaEditorJsField extends Field
     /**
      * Resolve the field's value for display.
      *
-     * @param  string|null  $attribute
      *
      * @throws \Throwable
      */
-    public function resolveForDisplay($resource, $attribute = null)
+    public function resolveForDisplay($resource, ?string $attribute = null): void
     {
         $attribute = $attribute ?? $this->attribute;
         if ($attribute === 'ComputedField') {

--- a/src/NovaEditorJsField.php
+++ b/src/NovaEditorJsField.php
@@ -51,7 +51,7 @@ class NovaEditorJsField extends Field
             return;
         }
 
-        $value = data_get($resource, str_replace('->', '.', $attribute), $placeholder = new \stdClass());
+        $value = data_get($resource, str_replace('->', '.', $attribute), $placeholder = new \stdClass);
 
         if (is_callable($this->resolveCallback)) {
             $value = call_user_func($this->resolveCallback, $value, $resource, $attribute);

--- a/tests/Feature/Http/Controllers/EditorJsImageUploadControllerTest.php
+++ b/tests/Feature/Http/Controllers/EditorJsImageUploadControllerTest.php
@@ -46,7 +46,7 @@ class EditorJsImageUploadControllerTest extends TestCase
         $fake = Event::fake();
         DB::setEventDispatcher($fake);
 
-        $uploadedFile = UploadedFile::fake()->create('file', 1024, (new finfo())->file($path, FILEINFO_MIME_TYPE));
+        $uploadedFile = UploadedFile::fake()->create('file', 1024, (new finfo)->file($path, FILEINFO_MIME_TYPE));
         if ($fp = $uploadedFile->openFile('w')) {
             $fp->fwrite(file_get_contents($path));
         }

--- a/tests/Feature/Views/ViewTestHelpers.php
+++ b/tests/Feature/Views/ViewTestHelpers.php
@@ -9,7 +9,7 @@ use Illuminate\Testing\TestView;
 
 trait ViewTestHelpers
 {
-    protected function view(string $view, array $args = []): TestView
+    protected function view(string $view, $args = []): TestView
     {
         return new TestView(View::make($view, $args));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,7 +23,7 @@ class TestCase extends OrchestraTestCase
      */
     protected function repairLaravel8Compatibiliy()
     {
-        if (! \Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'illuminate/support', '^8.0')) {
+        if (! \Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser, 'illuminate/support', '^8.0')) {
             return;
         }
 


### PR DESCRIPTION
- Updated `illuminate/support ` and `illuminate/events` to include support for version ^12.0.
- Upgraded `laravel/nova` from ^4.0 to ^5.0.

These changes ensure compatibility with the latest framework versions while maintaining support for previous versions