### PR TITLE
Allow us to configure the image driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ You can customize the views for each component, by changing the view in `resourc
 <sup>†</sup> The _Embeds_ tool is triggered by pasting URLs to embeddable
 content. It does not have an entry in the "Add" menu.
 
+### Changing the image driver
+
+You may change the image driver (default Imagick) via the configuration like so:
+
+```php
+return [
+  'toolSettings' => [
+    'image' => [
+      'imagedriver' => Spatie\Image\Enums\ImageDriver::Gd,
+      // ...
+    ],
+    // ...
+  ],
+  // ...
+];
+```
+
+Any option set here must be of type `Spatie\Image\Enums\ImageDriver`.
+
 ### Registering custom components
 
 Please refer to the [extending Nova EditorJS](./EXTENDING.md) guide on instructions on how to register custom

--- a/src/Http/Controllers/EditorJsImageUploadController.php
+++ b/src/Http/Controllers/EditorJsImageUploadController.php
@@ -129,7 +129,12 @@ class EditorJsImageUploadController extends Controller
     private function applyAlterations($path, $alterations = [])
     {
         try {
-            $image = Image::load($path);
+            if (! empty(config('nova-editor-js.toolSettings.image.imagedriver'))) {
+                $image = Image::useImageDriver(config('nova-editor-js.toolSettings.image.imagedriver'));
+                $image->loadFile($path);
+            } else {
+                $image = Image::load($path);
+            }
 
             $imageSettings = config('nova-editor-js.toolSettings.image.alterations');
 

--- a/src/config/nova-editor-js.php
+++ b/src/config/nova-editor-js.php
@@ -41,6 +41,7 @@ return [
             'shortcut' => 'CMD+SHIFT+I',
             'path' => 'public/images',
             'disk' => 'local',
+            'imagedriver' => Spatie\Image\Enums\ImageDriver::Imagick,
             'alterations' => [
                 'resize' => [
                     'width' => false, // integer


### PR DESCRIPTION
Allow the configuration of the image driver. We currently have a project where Imagick isn't available, and we'd like to use Gd instead. This should still keep Imagick as the default, but users can set Gd in the config and use that instead if desired.