### PR TITLE
feat: Add GitHub Issue Templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: File a bug report to help improve nova-editor-js
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: When I click X, Y happens instead of Z...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Where does this bug occur?
+      options:
+        - Laravel Nova (via composer)
+        - Standalone (direct npm/Laravel Mix)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of nova-editor-js are you using?
+      placeholder: "e.g. 4.0.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Please copy and paste any relevant log output.
+      render: shell
+
+  - type: checkboxes
+    id: gssoc
+    attributes:
+      label: GSSoC
+      options:
+        - label: I am a registered GSSoC 2026 contributor
+        - label: I would like to work on this bug

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest an idea for nova-editor-js
+title: "[FEATURE] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the Solution You'd Like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe Alternatives You've Considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the feature request here.
+
+  - type: checkboxes
+    id: gssoc
+    attributes:
+      label: GSSoC
+      options:
+        - label: I am a registered GSSoC 2026 contributor
+        - label: I would like to implement this feature myself


### PR DESCRIPTION
## What
Add YAML-based GitHub issue templates for bug reports and feature requests.

## Root cause
nova-editor-js has no issue templates, so bug reports and feature requests arrive with inconsistent information, making triage harder.

## Changes
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured form with description, steps to reproduce, expected vs actual behavior, environment, version, logs, and GSSoC checkbox
- `.github/ISSUE_TEMPLATE/feature_request.yml` — structured form with problem, proposed solution, alternatives, additional context, and GSSoC checkbox

## Verification
- Navigate to Issues → New Issue on the repo
- Both template options appear: "Bug Report" and "Feature Request"
- Each form shows the required fields and GSSoC checkboxes

## CI failures
N/A - configuration only change.

## Before
Issues created without structure — inconsistent information, harder triage.

## After
Structured YAML issue forms with validation and GSSoC contributor checkboxes.

Closes #131