### PR TITLE
docs: add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+﻿MIT License
+
+Copyright (c) 2026 advoor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Addresses #130 by adding the standard MIT License text to nova-editor-js.

## What changed
- **Added `LICENSE`** (21 lines) — the standard MIT License text with copyright assigned to advoor (year 2026).

## Why
nova-editor-js currently has no LICENSE file. Without one, the project falls under default copyright law, which prohibits anyone from legally using, modifying, or contributing. Adding MIT unblocks contribution and reuse, and matches the convention used by similar editor-extension projects.

## Testing
- 1 new file (LICENSE), 0 other files modified
- MIT License text is the canonical, unmodified form
- Renders correctly in GitHub

Closes #130